### PR TITLE
Updated command to enabled serial port RPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Connect your Toon's debugging header to a Raspberry Pi according to the followin
 
 
 Then make sure the serial port on the Pi is enabled and the serial console is disabled
-using `raspi_config` and reboot if necessary. Install the dependencies mentioned in the
+using `sudo raspi-config` and reboot if necessary. Install the dependencies mentioned in the
 [Dependencies](#dependencies)-section.
 
 Then get and run this application:


### PR DESCRIPTION
The `raspi-config` command can only be executed by sudo.
Also corrected the command itself by changing the `_` by a `-`

Hopefully it will help some.

Thanks alot