### PR TITLE
Raspberry Pi 5: How To info for others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ToonRooter
 
+
 ## What it does
 This application roots your Toon from a Raspberry Pi or another device with a JTAG debugger attached.
 


### PR DESCRIPTION
Hello,
I know this is not the right place/way to give this info but Issues are disabled on this git repo and I like to keep relevant stuff on platform not behind a login wall on another forum :-)


This is meant to help others who also have a Pi 5 and have to root a old Toon 1 via the JTAG way.

As the Pi5 uses a different chip for GPIO and Python2 being deprecated it is a little more difficult to get things working.

most instructions of the original repo can be followed except:
I followed an older commit state:
[71c1037](https://github.com/ToonSoftwareCollective/ToonRooter/tree/71c103757e0d0e5fb9acda96d9982c302d2385c5)

On the Pi 5 install
Rapberry Pi OS: Debian 12 (bookworm) (older won't boot)

Python2 download and compile:
```
sudo apt update
sudo apt install -y git build-essential autoconf automake libtool pkg-config texinfo \
libusb-1.0-0-dev libgpiod-dev gpiod libffi-dev zlib1g-dev libssl-dev libbz2-dev \
libreadline-dev libsqlite3-dev libncurses5-dev libgdbm-dev uuid-dev tk-dev
```
```
cd ~
wget https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz
tar xf Python-2.7.18.tgz
cd Python-2.7.18
./configure --prefix=/opt/python2 --enable-unicode=ucs4
make -j$(nproc)
sudo make install
sudo ln -s /opt/python2/bin/python2 /usr/local/bin/python2
```
```
cd ~
curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
sudo /opt/python2/bin/python2 get-pip.py "pip==20.3.4"
sudo /opt/python2/bin/pip2 install "pyserial==3.5"
```

Download and build OpenOCD for LinuxGPIO:
```
cd ~
git clone --recursive git://git.code.sf.net/p/openocd/code openocd
cd openocd
git fetch --tags
git checkout v0.12.0
git submodule update --init --recursive 
./bootstrap
./configure --enable-internal-jimtcl --enable-linuxgpiod --enable-sysfsgpio --prefix=/usr
make -j$(nproc)
sudo make install
```

Then because Python2 is not supported well anymore the following lines need to be commented out of __main__.py. this will disable ssh key generation by the python script.
```
#import sshkeys
    if args.ssh_public_key:
        with open(args.ssh_public_key, 'r') as f:
            ssh_pubkey_data = f.read()
        #if not sshkeys.check_public_key(ssh_pubkey_data):
        #    raise Exception("RSA key is not valid")
        log.info("Using RSA key in {}".format(args.ssh_public_key))
    #else:
    #    (pub, priv) = sshkeys.generate_key_pair(args.private_key_password)
    #    ssh_pubkey_data = pub
    #    with open("{}".format(args.output_ssh_key), 'w') as f:
    #        f.write(priv)
    #    with open("{}.pub".format(args.output_ssh_key), 'w') as f:
    #        f.write(pub)
    #    log.info("Written private and public key pair to {0} and {0}.pub, respectively".format(args.output_ssh_key))
```

This change requires manual generation of SSH key:
`ssh-keygen -t rsa -b 2048 -f ~/toon_rsa -N ""`

Then to use OpenOCD for rpi5 with this script add the following file:
~/ToonRooter/assets/adapters/rpi5.cfg 
```
# SPDX-License-Identifier: GPL-2.0-or-later

# Config for Raspberry Pi 5 used as a bitbang adapter.
# https://www.raspberrypi.com/documentation/computers/raspberry-pi.html

# Raspberry Pi 5 is not compatible with bcm2835gpio native GPIO driver.
# The linuxgpiod driver without configurable adapter speed runs at approximately
# 800 kHz (SWD writes) and 360 kHz (SWD reads)

adapter driver linuxgpiod

proc read_file { name } {
	if {[catch {open $name r} fd]} {
		return ""
	}
	set result [read $fd]
	close $fd
	return $result
}

proc find_rp1_alias {} {
	foreach f [glob -directory "/proc/device-tree/aliases" "gpio\[0-9\]"] {
		if {[string match "*/rp1/*" [read_file $f]]} {
			return $f
		}
	}
}

set pcie_aspm [read_file /sys/module/pcie_aspm/parameters/policy]
if {![string match {*\[performance\]*} $pcie_aspm]} {
	echo "Warn : Switch PCIe power saving off or the first couple of pulses gets clocked as fast as 20 MHz"
	echo "Warn : Issue 'echo performance | sudo tee /sys/module/pcie_aspm/parameters/policy'"
}

set GPIO_CHIP [string index [find_rp1_alias] end]
source [find interface/raspberrypi-gpio-connector.cfg]
```

you might need to edit the following file for TRST and SRST:
/usr/share/openocd/scripts/interface/raspberrypi-gpio-connector.cfg
```
# If you define trst or srst, use appropriate reset_config
# Header pin numbers: TRST - 26, SRST - 18

 adapter gpio trst -chip $_GPIO_CHIP 7
 #reset_config trst_only

 adapter gpio srst -chip $_GPIO_CHIP 24
# reset_config srst_only srst_push_pull

# or if you have both connected,
 reset_config trst_and_srst srst_push_pull
```

for the connections they also differ from the older Pi models:
```
JTAG |	GPIO |	PI  |	TOON
-----------------------------------
TRST |	7    |	26  |	2
GND  |	     |	25  |	3
TCK  |	11   |	23  |	4
GND  |	     |	20  |	5
TMS  |	8    |	24  |	6
     |	     |	    |
SRST |	24   |	18  |	7
     |	     |	    |
TDI  |	10   |	19  |	8
TDO  |	9    |	21  |	10
     |	     |	    |
RX(t)|	     |	8   |	11
TX(t)|	     |	10  |	13
GND  |	     |	9   |	14
```

Then run the following. (might have to manually reboot the Toon and/or run the script multiple times.)
`sudo python2 . --jtag-hardware rpi5 --ssh-public-key ~/toon_rsa.pub --serial-port /dev/ttyAMA0`

For me this was the output after i ran it a 3rd time and rebooted the toon manually when it got to the "Patching Toon" part.
```
KickingAnimal@raspberrypi-5:~/ToonRooter $ sudo python2 . --jtag-hardware rpi5 --ssh-public-key ~/toon_rsa.pub --serial-port /dev/ttyAMA0
INFO:__main__:Starting up...
INFO:__main__:Using RSA key in /home/dion-frankes/toon_rsa.pub
INFO:rooter:Waiting for Toon to restart
INFO:rooter:Toon has U-Boot version 2010.09-R6
INFO:rooter:Using password to log in
INFO:rooter:Logging in to U-Boot
INFO:rooter:Patching U-Boot
INFO:rooter:Waiting for boot up
INFO:rooter:Transferring payload
INFO:rooter:Patching Toon
INFO:rooter:>>> Enabling root user. Your root password is: [****]
INFO:rooter:>>> Opening ports 22, 80 and 10080 on firewall
INFO:rooter:>>> Disable VPN on boot
INFO:rooter:>>> Installing dropbear
INFO:rooter:>>> Installing openssh-sftp-server
INFO:rooter:Cleaning up
INFO:rooter:Rebooting
INFO:rooter:Your Toon is now rooted. Please wait for it to boot up and try to log in using SSH
```

hope this might help someone if they find an old Toon like I did